### PR TITLE
inital folder structure and account creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# extra
+.idea
+.vscode
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/1_account_creation/backend.tf
+++ b/1_account_creation/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    encrypt = true
+    region = "us-east-1"
+    key = "aws-organizations-demo/account-creation/terraform.tfstate"
+    # remember to set your bucket here
+  }
+}

--- a/1_account_creation/main.tf
+++ b/1_account_creation/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# this must be a unique email address
+# this will be used to perform the root user password reset when cleaning up (deleting) the account
+# (or use something like a gmail alias, ex: <username>+aws.orgs.dev@gmail.com)
+variable "dev_root_user_email_address" {
+  description = "Unique email address for the account"
+}
+
+resource "aws_organizations_account" "dev" {
+  email = var.dev_root_user_email_address
+  name = "dev"
+  # recommend using default `role_name` which is "OrganizationAccountAccessRole"
+  lifecycle {
+    ignore_changes = [role_name]
+  }
+}
+
+locals {
+  dev_iam_role = "arn:aws:iam::${aws_organizations_account.dev.id}:role/OrganizationAccountAccessRole"
+}
+
+output "dev_account_access_role" {
+  value = local.dev_iam_role
+}
+output "example_assume_role_command" {
+  value = "aws sts assume-role --role-arn ${local.dev_iam_role} --role-session-name foo"
+}

--- a/1_account_creation/versions.tf
+++ b/1_account_creation/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/2_account_config/backend.tf
+++ b/2_account_config/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    encrypt = true
+    region = "us-east-1"
+    key = "aws-orgainzations-demo/account-config/terraform.tfstate"
+    # remember to set your bucket here
+  }
+}

--- a/2_account_config/main.tf
+++ b/2_account_config/main.tf
@@ -1,0 +1,27 @@
+# root account
+provider "aws" {
+  region = "us-east-1"
+  alias = "root"
+}
+
+# Get the dev account's OrganizationAccountAccessRole
+data "aws_organizations_organization" "root" {
+  provider = aws.root
+}
+locals {
+  dev_account_id = data.aws_organizations_organization.root.non_master_accounts.*.id[0]
+  dev_account_arn = "arn:aws:iam::${local.dev_account_id}:role/OrganizationAccountAccessRole"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias = "dev"
+  assume_role {
+    role_arn = local.dev_account_arn
+  }
+}
+
+# Create resources
+resource "aws_sns_topic" "dev_foo" {
+  provider = aws.dev
+}

--- a/2_account_config/versions.tf
+++ b/2_account_config/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/README.md
+++ b/README.md
@@ -1,18 +1,60 @@
-# Automating-AWS-Organizations
+Automating-AWS-Organizations
+============================
 
 This repository ties to the following [blogpost]() and demonstrates how to setup and automate AWS Organizations using terraform from the beginning.
 
 It contains enough terraform to spin up an AWS Organization with the following resources:
+- Named accounts based on the variable account_names
+- AWS Service Directory for each account
+- Cross Account Super Horizontal IAM Roles for Tooling Automation
 
-* Named accounts based on the variable account_names
-* AWS Service Directory for each account
-* Cross Account Super Horizontal IAM Roles for Tooling Automation
+Index
+-----
+- `1_account_creation`
+    - this folder contains terraform to set up a new AWS Account under your root AWS account
+    - this is a somewhat separate activity since all subsequent actions 
+    are configuration which is completely ephemeral while this part is extremely static
+- `2_account_configuration`
+    - this folder contains terraform to configure Service Control Polices and automation IAM roles
 
-## Dependencies
+Caveats
+-------
+This terraform module will create AWS account attached to your Root AWS Account.
+Due to AWS limitations Terraform cannot destroy the new aws accounts when you are finished.
+This process is manual, the AWS API/SDK does not support account deletion.  
 
-* Terraform 13.X
-* AWS Credentials
+From the [AWS Docs](https://aws.amazon.com/premiumsupport/knowledge-center/close-aws-account/):
+> To close an account, you must be signed in as the AWS account root user of the account.
+> If you sign in to an account with an AWS Identity and Access Management (IAM) user or role, you can't close the account.
+> 
+> Member accounts created using AWS Organizations by default don't have a root password. 
+> You must reset the root user password for these accounts before you can sign in as the root user.
 
-## How to Develop
+To clean up:
+- Perform a Root user [password reset](https://aws.amazon.com/premiumsupport/knowledge-center/recover-aws-password/) on the child AWS account
+    - warning: this must be done before running terraform destroy
+- run `terraform destroy` to destroy all resources 
+  and remove the child AWS resources (policies/roles/etd). 
+- Log in to the child account with the root user, navigate to account settings, and delete the account  
 
-Pull down the repository, ...
+Dependencies
+------------
+- Terraform 13.X
+- AWS Account and Credentials
+
+How to Deploy
+-------------
+- Clone the repository
+- `terraform init`
+- `terraform apply`
+
+How to Develop
+--------------
+- Clone the repository
+- `terraform init`
+- `terraform plan` and `terraform apply`
+
+Links
+-----
+- Create AWS Org and Account
+    - https://aws.amazon.com/blogs/security/how-to-use-aws-organizations-to-automate-end-to-end-account-creation/ 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Automating-AWS-Organizations
+
+This repository ties to the following [blogpost]() and demonstrates how to setup and automate AWS Organizations using terraform from the beginning.
+
+It contains enough terraform to spin up an AWS Organization with the following resources:
+
+* Named accounts based on the variable account_names
+* AWS Service Directory for each account
+* Cross Account Super Horizontal IAM Roles for Tooling Automation
+
+## Dependencies
+
+* Terraform 13.X
+* AWS Credentials
+
+## How to Develop
+
+Pull down the repository, ...


### PR DESCRIPTION
I have broken the Terraform into two folders. One to detail the account creation using AWS organizations. The second to detail the account configuration. I view account configuration separate from creation due to the extremely static nature of AWS accounts vs resources in the AWS accounts.